### PR TITLE
Fix signedness mismatch

### DIFF
--- a/lib/Crypt/TweetNacl/Basics.pm6
+++ b/lib/Crypt/TweetNacl/Basics.pm6
@@ -42,11 +42,11 @@ class CryptoHash is export {
 # void randombytes(unsigned char *x,unsigned long long xlen)
 
 # todo check signedness of xlen
-sub randombytes_int(CArray[int8], ulonglong) is symbol('randombytes') is native(TWEETNACL) is export { * }
+sub randombytes_int(CArray[uint8], ulonglong) is symbol('randombytes') is native(TWEETNACL) is export { * }
 
 sub randombytes(int $xlen!) is export
 {
-    my $data = CArray[int8].new;
+    my $data = CArray[uint8].new;
     $data[$xlen - 1] = 0;
     randombytes_int($data, $xlen);
     return $data;
@@ -60,7 +60,7 @@ sub nonce() is export
 sub prepend_zeros($buf!, Int $num_zeros!) is export
 {
     my $mlen = $num_zeros + $buf.elems;
-    my $msg  = CArray[int8].new;
+    my $msg  = CArray[uint8].new;
     $msg[$mlen - 1] = 0;        #alloc
     my Int $i;
     loop ($i=0; $i < $num_zeros ; $i++)
@@ -82,7 +82,7 @@ class Ciphertext is export
 
     submethod BUILD(CArray :$zdata!, CArray :$nonce!)
     {
-        $!data = remove_leading_elems(CArray[int8], $zdata, CRYPTO_BOX_BOXZEROBYTES);
+        $!data = remove_leading_elems(CArray[uint8], $zdata, CRYPTO_BOX_BOXZEROBYTES);
         $!dlen = $!data.elems;
         $!nonce = $nonce;
     }

--- a/lib/Crypt/TweetNacl/PublicKey.pm6
+++ b/lib/Crypt/TweetNacl/PublicKey.pm6
@@ -136,7 +136,7 @@ DOC INIT {
 # https://nacl.cr.yp.to/box.html
 # int crypto_box_keypair(u8 *y,u8 *x);
 
-sub crypto_box_keypair_int(CArray[int8], CArray[int8]) is symbol('crypto_box_keypair') is native(TWEETNACL) returns int { * }
+sub crypto_box_keypair_int(CArray[uint8], CArray[uint8]) is symbol('crypto_box_keypair') is native(TWEETNACL) returns int { * }
 
 class KeyPair is export
 {
@@ -144,8 +144,8 @@ class KeyPair is export
     has $.public;
     submethod BUILD()
     {
-        $!secret := CArray[int8].new;
-        $!public := CArray[int8].new;
+        $!secret := CArray[uint8].new;
+        $!public := CArray[uint8].new;
         $!secret[CRYPTO_BOX_SECRETKEYBYTES - 1] = 0; # extend the array to 32 items
         $!public[CRYPTO_BOX_PUBLICKEYBYTES - 1] = 0; # extend the array to 32 items
         my $ret = crypto_box_keypair_int($!public,$!secret);
@@ -166,7 +166,7 @@ class KeyPair is export
 
 #      crypto_box_beforenm(k,pk,sk);#int crypto_box_beforenm(u8 *k,const u8 *y,const u8 *x);
 
-sub crypto_box_beforenm_int (CArray[int8], CArray[int8], CArray[int8]) is symbol('crypto_box_beforenm') is native(TWEETNACL) is export returns int32 { * };
+sub crypto_box_beforenm_int (CArray[uint8], CArray[uint8], CArray[uint8]) is symbol('crypto_box_beforenm') is native(TWEETNACL) is export returns int32 { * };
 
 # const unsigned char k[crypto_box_BEFORENMBYTES];
 # const unsigned char n[crypto_box_NONCEBYTES];
@@ -175,7 +175,7 @@ sub crypto_box_beforenm_int (CArray[int8], CArray[int8], CArray[int8]) is symbol
 
 # crypto_box_open_afternm(m,c,clen,n,k);
 
-sub crypto_box_afternm_int (CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8]) is symbol('crypto_box_afternm') is native(TWEETNACL) is export returns int32 { * };
+sub crypto_box_afternm_int (CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8]) is symbol('crypto_box_afternm') is native(TWEETNACL) is export returns int32 { * };
 
 
 class CryptoBox is export
@@ -183,7 +183,7 @@ class CryptoBox is export
     has $!key;
     submethod BUILD(CArray :$pk!, CArray :$sk!)
     {
-        $!key := CArray[int8].new;
+        $!key := CArray[uint8].new;
         $!key[CRYPTO_BOX_BEFORENMBYTES - 1] = 0; # extend the array to 32 items
         my $ret = crypto_box_beforenm_int($!key, $pk, $sk);
         if ($ret != 0) {
@@ -194,7 +194,7 @@ class CryptoBox is export
     multi method encrypt(Blob $buf!, CArray $nonce!)
     {
         my ulonglong $mlen = CRYPTO_BOX_ZEROBYTES + $buf.elems;
-        my $data = CArray[int8].new;
+        my $data = CArray[uint8].new;
         $data[$mlen - 1] = 0;   #alloc
         my $msg  = prepend_zeros($buf, CRYPTO_BOX_ZEROBYTES);
         my $ret = crypto_box_afternm_int($data, $msg, $mlen, $nonce, $!key);
@@ -226,14 +226,14 @@ class CryptoBox is export
 
 #    crypto_box_open_afternm(m,c,clen,n,k)
 
-sub crypto_box_open_afternm_int(CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8]) is symbol('crypto_box_open_afternm') is native(TWEETNACL) is export returns int32 { * }
+sub crypto_box_open_afternm_int(CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8]) is symbol('crypto_box_open_afternm') is native(TWEETNACL) is export returns int32 { * }
 
 class CryptoBoxOpen is export
 {
     has $!key;
     submethod BUILD(CArray :$pk!, CArray :$sk!)
     {
-        $!key := CArray[int8].new;
+        $!key := CArray[uint8].new;
         $!key[CRYPTO_BOX_BEFORENMBYTES - 1] = 0; # extend the array to 32 items
         my $ret = crypto_box_beforenm_int($!key, $pk, $sk);
         if ($ret != 0) {
@@ -242,7 +242,7 @@ class CryptoBoxOpen is export
     }
     multi method decrypt(CArray $c!, CArray $nonce!)
     {
-        my $msg  = CArray[int8].new;
+        my $msg  = CArray[uint8].new;
         my $clen = $c.elems;
         $msg[$clen - 1] = 0;    #alloc
         my $i;
@@ -280,12 +280,12 @@ class CryptoBoxOpen is export
 #
 #     crypto_box(c,m,mlen,n,pk,sk);
 
-sub crypto_box_int (CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8], CArray[int8]) is symbol('crypto_box') is native(TWEETNACL) is export returns int32 { * };
+sub crypto_box_int (CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8], CArray[uint8]) is symbol('crypto_box') is native(TWEETNACL) is export returns int32 { * };
 
 sub crypto_box (Blob $buf!, CArray $nonce!, CArray $pk!, CArray $sk!) is export
 {
     my ulonglong $mlen = CRYPTO_BOX_ZEROBYTES + $buf.elems;
-    my $data = CArray[int8].new;
+    my $data = CArray[uint8].new;
     $data[$mlen - 1] = 0;       #alloc
     my $msg  = prepend_zeros($buf, CRYPTO_BOX_ZEROBYTES);
     my $ret = crypto_box_int($data, $msg, $mlen, $nonce, $pk, $sk);
@@ -302,12 +302,12 @@ sub crypto_box (Blob $buf!, CArray $nonce!, CArray $pk!, CArray $sk!) is export
 #     unsigned char m[...];
 #     crypto_box_open(m,c,clen,n,pk,sk);
 
-sub crypto_box_open_int(CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8], CArray[int8]) is symbol('crypto_box_open') is native(TWEETNACL) is export returns int32 { * }
+sub crypto_box_open_int(CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8], CArray[uint8]) is symbol('crypto_box_open') is native(TWEETNACL) is export returns int32 { * }
 
 
 sub crypto_box_open(CArray $c!, CArray $nonce!, CArray $pk!, CArray $sk!) is export
 {
-    my $msg  = CArray[int8].new;
+    my $msg  = CArray[uint8].new;
     my $clen = $c.elems;
     $msg[$clen - 1] = 0;        #alloc
     my $i;

--- a/lib/Crypt/TweetNacl/SecretKey.pm6
+++ b/lib/Crypt/TweetNacl/SecretKey.pm6
@@ -117,7 +117,7 @@ DOC INIT {
 # of the ciphertext c are all 0.
 
 
-sub crypto_secretbox_int (CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8]) is symbol('crypto_secretbox') is native(TWEETNACL) is export returns int32 { * };
+sub crypto_secretbox_int (CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8]) is symbol('crypto_secretbox') is native(TWEETNACL) is export returns int32 { * };
 
 # C NaCl also provides a crypto_secretbox_open function callable as follows:
 
@@ -146,7 +146,7 @@ sub crypto_secretbox_int (CArray[int8], CArray[int8], ulonglong, CArray[int8], C
 # (in case of success) that the first crypto_secretbox_ZEROBYTES bytes
 # of the plaintext m are all 0.
 
-sub crypto_secretbox_open_int (CArray[int8], CArray[int8], ulonglong, CArray[int8], CArray[int8]) is symbol('crypto_secretbox_open') is native(TWEETNACL) is export returns int32 { * };
+sub crypto_secretbox_open_int (CArray[uint8], CArray[uint8], ulonglong, CArray[uint8], CArray[uint8]) is symbol('crypto_secretbox_open') is native(TWEETNACL) is export returns int32 { * };
 
 
 class Key is export
@@ -172,7 +172,7 @@ class CryptoSecretBox is export
     multi method encrypt(Blob $buf!, CArray $nonce!)
     {
         my ulonglong $mlen = CRYPTO_SECRETBOX_ZEROBYTES + $buf.elems;
-        my $data = CArray[int8].new;
+        my $data = CArray[uint8].new;
         $data[$mlen - 1] = 0;   #alloc
         my $msg  = prepend_zeros($buf, CRYPTO_SECRETBOX_ZEROBYTES);
         my $ret = crypto_secretbox_int($data, $msg, $mlen, $nonce, $!key);
@@ -204,7 +204,7 @@ class CryptoSecretBoxOpen is export
 
     multi method decrypt(CArray $c!, CArray $nonce!)
     {
-        my $msg  = CArray[int8].new;
+        my $msg  = CArray[uint8].new;
         my $clen = $c.elems;
         $msg[$clen - 1] = 0;    #alloc
         my $i;

--- a/lib/Crypt/TweetNacl/Sign.pm6
+++ b/lib/Crypt/TweetNacl/Sign.pm6
@@ -78,7 +78,7 @@ DOC INIT {
 
 #     crypto_sign_keypair(pk,sk);
 
-sub crypto_sign_keypair_int(CArray[int8], CArray[int8]) is symbol('crypto_sign_keypair') is native(TWEETNACL) returns int { * }
+sub crypto_sign_keypair_int(CArray[uint8], CArray[uint8]) is symbol('crypto_sign_keypair') is native(TWEETNACL) returns int { * }
 
 class KeyPair is export
 {
@@ -86,8 +86,8 @@ class KeyPair is export
     has $.public;
     submethod BUILD()
     {
-        $!secret := CArray[int8].new;
-        $!public := CArray[int8].new;
+        $!secret := CArray[uint8].new;
+        $!public := CArray[uint8].new;
         $!secret[CRYPTO_SIGN_SECRETKEYBYTES - 1] = 0; # extend the array to 32 items
         $!public[CRYPTO_SIGN_PUBLICKEYBYTES - 1] = 0; # extend the array to 32 items
         my $ret = crypto_sign_keypair_int($!public,$!secret);
@@ -119,19 +119,19 @@ class KeyPair is export
 # caller must allocate at least mlen+crypto_sign_BYTES bytes for sm.
 
 #my $len = CArray[ulonglong].new; $len[0] = 0;
-sub crypto_sign_int(CArray[int8], CArray[ulonglong], CArray[int8], ulonglong, CArray[int8]) is symbol('crypto_sign') is native(TWEETNACL) returns int { * }
-sub crypto_sign_open_int(CArray[int8], CArray[ulonglong], CArray[int8], ulonglong, CArray[int8]) is symbol('crypto_sign_open') is native(TWEETNACL) returns int { * }
+sub crypto_sign_int(CArray[uint8], CArray[ulonglong], CArray[uint8], ulonglong, CArray[uint8]) is symbol('crypto_sign') is native(TWEETNACL) returns int { * }
+sub crypto_sign_open_int(CArray[uint8], CArray[ulonglong], CArray[uint8], ulonglong, CArray[uint8]) is symbol('crypto_sign_open') is native(TWEETNACL) returns int { * }
 
 
 class CryptoSign is export
 {
     has $.signature;
-    submethod BUILD(Blob :$buf!, CArray[int8] :$sk!)
+    submethod BUILD(Blob :$buf!, CArray[uint8] :$sk!)
     {
         my $mlen = $buf.elems;
-        $!signature = CArray[int8].new;
-        my $msg = CArray[int8].new;
-        my $tmp = CArray[int8].new;
+        $!signature = CArray[uint8].new;
+        my $msg = CArray[uint8].new;
+        my $tmp = CArray[uint8].new;
         $tmp[CRYPTO_SIGN_BYTES + $mlen - 1] = 0;
         my $i;
         loop ($i=0; $i < $buf.elems; ++$i)
@@ -179,11 +179,11 @@ class CryptoSign is export
 class CryptoSignOpen is export
 {
     has $.message;
-    submethod BUILD(CArray[int8] :$buf!, CArray[int8] :$pk!)
+    submethod BUILD(CArray[uint8] :$buf!, CArray[uint8] :$pk!)
     {
         my $smlen = $buf.elems;
         my $imessage := Buf.new;
-        my $tmp = CArray[int8].new;
+        my $tmp = CArray[uint8].new;
         $tmp[$smlen - 1] = 0;
         my $i;
         my $mlen = CArray[ulonglong].new;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -8,8 +8,8 @@ plan 5;
 
 
 my $keypair = KeyPair.new;
-isa-ok $keypair.secret, CArray[int8];
-isa-ok $keypair.public, CArray[int8];
+isa-ok $keypair.secret, CArray[uint8];
+isa-ok $keypair.public, CArray[uint8];
 
 is $keypair.secret.elems, CRYPTO_BOX_SECRETKEYBYTES;
 is $keypair.public.elems, CRYPTO_BOX_PUBLICKEYBYTES;

--- a/t/02-random.t
+++ b/t/02-random.t
@@ -23,4 +23,4 @@ say $b;
 is $same , Bool::False;
 
 my $n = nonce();
-isa-ok CArray[int8], $n;
+isa-ok CArray[uint8], $n;

--- a/t/03-crypto_box.t
+++ b/t/03-crypto_box.t
@@ -9,7 +9,7 @@ my $alice = KeyPair.new;
 my $bob = KeyPair.new;
 my $msg = 'Hello World'.encode('UTF-8');
 
-my CArray[int8] $nonce = nonce();
+my CArray[uint8] $nonce = nonce();
 my $data1 = crypto_box($msg, $nonce, $alice.public , $bob.secret);
 my $rmsg1 = crypto_box_open($data1, $nonce, $bob.public , $alice.secret);
 is $rmsg1.decode('UTF-8'), $msg , "Roundtrip encrypt->decrypt";

--- a/t/06-sign.t
+++ b/t/06-sign.t
@@ -7,15 +7,15 @@ use NativeCall;
 plan 7;
 
 my $keypair = KeyPair.new;
-isa-ok $keypair.secret, CArray[int8];
-isa-ok $keypair.public, CArray[int8];
+isa-ok $keypair.secret, CArray[uint8];
+isa-ok $keypair.public, CArray[uint8];
 
 is $keypair.secret.elems, CRYPTO_SIGN_SECRETKEYBYTES;
 is $keypair.public.elems, CRYPTO_SIGN_PUBLICKEYBYTES;
 
 my $msg = 'Hello World'.encode('UTF-8');
 my $cs = CryptoSign.new(buf => $msg, sk => $keypair.secret);
-isa-ok $cs.signature, CArray[int8];
+isa-ok $cs.signature, CArray[uint8];
 is $cs.signature.elems, 75;
 
 


### PR DESCRIPTION
NaCl deals with unsigned char buffers, so CArray[uint8] is the correct Raku
type. As elements are moved between these and Buf (which by default is uint8)
we need to use the same types consistently.

This is required for the next Rakudo version which is more picky about int/uint.