### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -18,7 +18,7 @@
     ],
     "description" : "tweetnacl p6 bindings - public/secret key encryption and signatures",
     "test-depends" : [ ],
-    "version" : "0.0.3",
+    "version" : "0.0.4",
     "license"       : "Public Domain",
     "authors" : [
         "Frank Hartmann"


### PR DESCRIPTION
The Raku Ecosystem Archive has an older release stored as 0.0.3. Bump the version to get the fix for PR #4.